### PR TITLE
Bring back Cookie token extractor

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,11 +31,27 @@ function init (options = {}) {
       throw new Error(`Can not find app.passport. Did you initialize feathers-authentication before @feathersjs/authentication-jwt?`);
     }
 
-    let authOptions = app.get('auth') || app.get('authentication') || {};
-    let jwtOptions = authOptions[options.name] || {};
+    const authOptions = app.get('auth') || app.get('authentication') || {};
+    const jwtOptions = authOptions[options.name] || {};
 
     // NOTE (EK): Pull from global auth config to support legacy auth for an easier transition.
-    let jwtSettings = merge({}, defaults, pick(authOptions, KEYS), jwtOptions, omit(options, ['Verifier']));
+    const jwtSettings = merge({}, defaults, pick(authOptions, KEYS), jwtOptions, omit(options, ['Verifier']));
+    const extractors = [
+      ExtractJwt.fromAuthHeaderWithScheme('jwt'),
+      ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ExtractJwt.fromHeader(jwtSettings.header.toLowerCase()),
+      ExtractJwt.fromBodyField(jwtSettings.bodyKey)
+    ];
+
+    if (authOptions.cookie && authOptions.cookie.name) {
+      extractors.push(function (req) {
+        if (req && req.cookies) {
+          return req.cookies[authOptions.cookie.name];
+        }
+
+        return null;
+      });
+    }
 
     if (typeof jwtSettings.header !== 'string') {
       throw new Error(`You must provide a 'header' in your authentication configuration or pass one explicitly`);
@@ -48,12 +64,7 @@ function init (options = {}) {
     let Verifier = DefaultVerifier;
     let strategyOptions = merge({
       secretOrKey: jwtSettings.secret,
-      jwtFromRequest: ExtractJwt.fromExtractors([
-        ExtractJwt.fromAuthHeaderWithScheme('jwt'),
-        ExtractJwt.fromAuthHeaderAsBearerToken(),
-        ExtractJwt.fromHeader(jwtSettings.header.toLowerCase()),
-        ExtractJwt.fromBodyField(jwtSettings.bodyKey)
-      ])
+      jwtFromRequest: ExtractJwt.fromExtractors(extractors)
     }, jwtSettings.jwt, omit(jwtSettings, ['jwt', 'header', 'secret']));
 
     // Normalize algorithm key

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,9 +33,13 @@ function init (options = {}) {
 
     const authOptions = app.get('auth') || app.get('authentication') || {};
     const jwtOptions = authOptions[options.name] || {};
-
     // NOTE (EK): Pull from global auth config to support legacy auth for an easier transition.
     const jwtSettings = merge({}, defaults, pick(authOptions, KEYS), jwtOptions, omit(options, ['Verifier']));
+
+    if (typeof jwtSettings.header !== 'string') {
+      throw new Error(`You must provide a 'header' in your authentication configuration or pass one explicitly`);
+    }
+
     const extractors = [
       ExtractJwt.fromAuthHeaderWithScheme('jwt'),
       ExtractJwt.fromAuthHeaderAsBearerToken(),
@@ -51,14 +55,6 @@ function init (options = {}) {
 
         return null;
       });
-    }
-
-    if (typeof jwtSettings.header !== 'string') {
-      throw new Error(`You must provide a 'header' in your authentication configuration or pass one explicitly`);
-    }
-
-    if (typeof jwtSettings.secret === 'undefined') {
-      throw new Error(`You must provide a 'secret' in your authentication configuration or pass one explicitly`);
     }
 
     let Verifier = DefaultVerifier;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -48,7 +48,13 @@ describe('@feathersjs/authentication-jwt', () => {
     beforeEach(done => {
       app = expressify(feathers());
       app.use('/users', memory());
-      app.configure(authentication({ secret: 'supersecret' }));
+      app.configure(authentication({
+        secret: 'supersecret',
+        cookie: {
+          enabled: true,
+          name: 'feathers-jwt'
+        }
+      }));
 
       app.service('users').create({
         name: 'test user'
@@ -208,6 +214,26 @@ describe('@feathersjs/authentication-jwt', () => {
             authorization: `Bearer ${validToken}`
           },
           cookies: {}
+        };
+
+        app.configure(jwt());
+        app.setup();
+
+        return app.authenticate('jwt')(req).then(result => {
+          expect(result.success).to.equal(true);
+        });
+      });
+    });
+
+    describe('Cookie', () => {
+      it('authenticates using a cookie if set in options', () => {
+        const req = {
+          query: {},
+          body: {},
+          headers: {},
+          cookies: {
+            'feathers-jwt': validToken
+          }
         };
 
         app.configure(jwt());

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -80,14 +80,6 @@ describe('@feathersjs/authentication-jwt', () => {
       }).to.throw();
     });
 
-    it('throws an error if secret is not provided', () => {
-      expect(() => {
-        app = expressify(feathers());
-        app.configure(authentication({}));
-        app.setup();
-      }).to.throw();
-    });
-
     it('registers the jwt passport strategy', () => {
       sinon.spy(app.passport, 'use');
       sinon.spy(passportJWT, 'Strategy');


### PR DESCRIPTION
This pull request brings back parsing the JWT from the cookie. It will only be available if the `cookieParser` middleware has been registered (which we are not doing by default) and authentication cookies are enabled.

This change touches on many open issues, specifically in regards to using authentication for server side rendering and adding multiple accounts to the same user. Related issues:

- https://github.com/feathersjs/authentication/issues/389
- https://github.com/feathersjs/authentication/issues/550
- https://github.com/feathersjs/authentication/issues/402
- https://github.com/feathersjs/authentication-oauth2/issues/18
- https://github.com/feathersjs/authentication/issues/626
- https://github.com/feathersjs/authentication/issues/619
- https://github.com/feathersjs/authentication/issues/607
- https://github.com/feathersjs/authentication/issues/617
- https://github.com/feathersjs/authentication/issues/560
- https://github.com/feathersjs/authentication/issues/550
- https://github.com/feathersjs/authentication/issues/469
- https://github.com/feathersjs/authentication/issues/402
- https://github.com/feathersjs/feathers/issues/661
- https://github.com/feathersjs/feathers/issues/574